### PR TITLE
GTK compability & skeleton for openbox & kde

### DIFF
--- a/modules/packagechooser_DE.conf
+++ b/modules/packagechooser_DE.conf
@@ -96,6 +96,12 @@ items:
               description: Plasma integration for controlling Thunderbolt devices
             - name: kdeconnect
               description: Adds communication between KDE and your smartphone        
+            - name: xsettingsd 
+              description: Provides settings to X11 applications via the XSETTINGS specification       
+            - name: kde-gtk-config 
+              description: GTK2 and GTK3 Configurator for KDE
+            - name: rebornos-kde-skel
+              description: A basic skeleton for KDE to fix issues it has out of the box
             # ===========
             # XDG related (like xdg-desktop-portal-gnome, xdg-user-dirs-gtk, archlinux-xdg-menu)
             # ===========
@@ -132,6 +138,8 @@ items:
               description: Additional wallpapers for the Plasma Workspace
             - name: kdegraphics-thumbnailers
               description: Thumbnailers for various graphics file formats
+            - name: breeze-gtk
+              description: Breeze widget theme for GTK 2 and 3
             # ===========
             # Tweaking apps (like gnome-tweaks)
             # ===========
@@ -2617,6 +2625,8 @@ items:
               description: Monitor configuration tool  
             - name: lxtask-gtk3   
               description: Task manager of the LXDE Desktop   
+            - name: rebornos-openbox-skel 
+              description: Skeleton for fixing openbox issues  
             # ===========
             # XDG related (like xdg-desktop-portal-gnome, xdg-user-dirs-gtk, archlinux-xdg-menu)
             # ===========
@@ -2665,7 +2675,7 @@ items:
             # ===========
             # Text Editor
             # ===========
-            - name: leafpad
+            - name: geany
               description: Text Editor
             # ===============
             # Document Viewer


### PR DESCRIPTION
Replace leafpad with geany, add gtk compability programs to kde by default, add openbox and kde skeletons to fix their open issues