### PR TITLE
chore: remove incorrectly used packages

### DIFF
--- a/etc/calamares/modules/netinstall.yaml
+++ b/etc/calamares/modules/netinstall.yaml
@@ -484,8 +484,6 @@
             description: For Kepler (NVE0/GKXXX) series
           - name: nvidia-390xx-dkms
             description: For Fermi (NVC0/GF1XX) series
-          - name: nvidia-340xx-dkms
-            description: (Unsupported) For Tesla (NV50/G80-90-GT2XX) series
         subgroups: 
           - name: Nvidia Hybrid
             description: Nvidia Discrete with other integrated GPUs
@@ -670,7 +668,6 @@
         subgroups: 
           - name: Commandline
             packages:
-              - fdisk
               - parted
               - util-linux         
           - name: Graphical
@@ -688,7 +685,6 @@
             description: exFAT support
             packages: 
               - exfatprogs
-              - exfat-utils
           # - name: APFS
           #   description: (AUR) APFS support
           #   packages: 
@@ -716,8 +712,6 @@
               description: BTRFS support
             - name: xfsprogs
               description: XFS support
-            - name: reiserfsprogs
-              description: ReiserFS support
             - name: f2fs-tools
               description: F2FS support
             - name: hfsprogs
@@ -728,8 +722,6 @@
               description: NILFS2 support          
             - name: udftools
               description: UDF support
-            - name: reiser4progs
-              description: Reiser4 support
   - name: Input
     description: "Input device drivers for mouse, touchpad, keyboard, etc."
     packages: 

--- a/etc/calamares/post_install/post_install.py
+++ b/etc/calamares/post_install/post_install.py
@@ -25,7 +25,6 @@ NVIDIA_PACKAGES: List[str] = [
     "nvidia-open-dkms",
     "nvidia-470xx-dkms",
     "nvidia-390xx-dkms",
-    "nvidia-340xx-dkms",
 ]
 
 LOGGING_FORMAT: str = '%(asctime)s [%(levelname)8s] %(message)s (%(funcName)s; Line %(lineno)d)'

--- a/etc/calamares/post_install/rootfs/etc/pacman.d/hooks/nvidia.hook
+++ b/etc/calamares/post_install/rootfs/etc/pacman.d/hooks/nvidia.hook
@@ -5,13 +5,13 @@ Operation = Remove
 Type = Package
 Target = nvidia
 Target = nvidia-lts
-Target = nvidia-dkms 
+Target = nvidia-dkms
 Target = nvidia-beta
 Target = nvidia-open
 Target = nvidia-open-dkms
 Target = nvidia-470xx-dkms
 Target = nvidia-390xx-dkms
-Target = nvidia-340xx-dkms           
+Target = nvidia-340xx-dkms
 
 [Action]
 Description=Update NVIDIA module in initcpio


### PR DESCRIPTION
remove(netinstall): remove nvidia-340xx-dkms from supported Nvidia drivers (no longer in rebornos repository)
remove(netinstall): remove fdisk, not a package, part of util-linux remove(netinstall): remove exfat-utils, no longer needed since linux kernel 5.4+
remove(netinstall): remove reisergs (reiser4progs) from the filesystem list

remove(post_install): remove nvidia-340xx-dkms from the Nvidia packages list

chore(nvidia.hook): trim trailing spaces