### PR TITLE
changed budgie-desktop xdg from gnome to gtk

### DIFF
--- a/etc/calamares/modules/packagechooser_DE.conf
+++ b/etc/calamares/modules/packagechooser_DE.conf
@@ -908,7 +908,7 @@ items:
             # ===========
             # XDG related (like xdg-desktop-portal-gnome, xdg-user-dirs-gtk, archlinux-xdg-menu)
             # ===========
-            - name: xdg-desktop-portal-gnome
+            - name: xdg-desktop-portal-gtk
               description: XDG Desktop Portal
             # ============
             # Polkit agent


### PR DESCRIPTION
budgie-desktop was dependent on xdg-desktop-portal-gnome, it is now changed to xdg-desktop-portal-gtk to avoid possible dependency problem with mutter43 and mutter(44) which is what Gnome depends on.